### PR TITLE
Contrato inicial Reportes

### DIFF
--- a/reportes_view/Cargo.toml
+++ b/reportes_view/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "reportes_view"
+version = "0.1.0"
+authors = ["Jose <jose@example.com>"]
+edition = "2021"
+
+[dependencies]
+ink = { version = "5.1.1", default-features = false }
+scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
+scale-info = { version = "2.6", default-features = false, features = ["derive"] }
+market_place = { package = "marketplace_rust", path = "..", default-features = false, features = ["ink-as-dependency"] }
+
+[dev-dependencies]
+ink_e2e = "5.1.1"
+
+[lib]
+path = "lib.rs"
+
+[features]
+default = ["std"]
+std = [
+    "ink/std",
+    "scale/std",
+    "scale-info/std",
+    "market_place/std",
+]
+ink-as-dependency = []
+e2e-tests = []

--- a/reportes_view/lib.rs
+++ b/reportes_view/lib.rs
@@ -1,0 +1,225 @@
+#![cfg_attr(not(feature = "std"), no_std, no_main)]
+
+#[ink::contract]
+mod reportes_view {
+    use ink::env::call::FromAccountId;
+    use ink::prelude::string::String;
+    use ink::prelude::vec::Vec;
+    use ink::prelude::collections::BTreeMap;
+    use market_place::market_place::MarketPlaceRef;
+    use market_place::market_place::Categoria;
+    use market_place::market_place::Orden;
+    use market_place::market_place::Producto;
+    use market_place::market_place::EstadoOrden;
+
+    #[ink(storage)]
+    pub struct ReportesView {
+        marketplace: MarketPlaceRef,
+    }
+
+    impl ReportesView {
+        #[ink(constructor)]
+        pub fn new(marketplace_address: AccountId) -> Self {
+            let marketplace = MarketPlaceRef::from_account_id(marketplace_address);
+            Self { marketplace }
+        }
+
+        /// Consultar top 5 vendedores con mejor reputación.
+        #[ink(message)]
+        pub fn top_5_vendedores(&self) -> Vec<(AccountId, u32)> {
+            // Como no podemos iterar sobre los mappings del otro contrato directamente,
+            // y no hay una lista de todos los vendedores expuesta,
+            // necesitamos una forma de obtener los vendedores.
+            // Una opción es iterar sobre todas las órdenes y extraer los vendedores únicos.
+            // Esto es ineficiente pero dado las limitaciones de acceso es una opción.
+            // O mejor, iterar sobre las órdenes y acumular reputación si pudiéramos acceder a ella.
+            // Pero MarketPlace tiene `get_reputacion_vendedor`.
+            // Así que iteramos órdenes -> obtenemos vendedores -> obtenemos su reputación.
+            
+            let cantidad_ordenes = self.marketplace.get_cantidad_ordenes();
+            let mut vendedores_set = Vec::new();
+
+            for i in 0..cantidad_ordenes {
+                if let Some(orden) = self.marketplace.get_orden(i) {
+                    if !vendedores_set.contains(&orden.vendedor) {
+                        vendedores_set.push(orden.vendedor);
+                    }
+                }
+            }
+
+            let mut vendedores_reputacion: Vec<(AccountId, u32)> = Vec::new();
+            for vendedor in vendedores_set {
+                if let Some((_, puntaje_total)) = self.marketplace.get_reputacion_vendedor(vendedor) {
+                    vendedores_reputacion.push((vendedor, puntaje_total));
+                }
+            }
+
+            // Ordenar por puntaje descendente
+            vendedores_reputacion.sort_by(|a, b| b.1.cmp(&a.1));
+
+            // Retornar top 5
+            vendedores_reputacion.into_iter().take(5).collect()
+        }
+
+        /// Consultar top 5 compradores con mejor reputación.
+        #[ink(message)]
+        pub fn top_5_compradores(&self) -> Vec<(AccountId, u32)> {
+            let cantidad_ordenes = self.marketplace.get_cantidad_ordenes();
+            let mut compradores_set = Vec::new();
+
+            for i in 0..cantidad_ordenes {
+                if let Some(orden) = self.marketplace.get_orden(i) {
+                    if !compradores_set.contains(&orden.comprador) {
+                        compradores_set.push(orden.comprador);
+                    }
+                }
+            }
+
+            let mut compradores_reputacion: Vec<(AccountId, u32)> = Vec::new();
+            for comprador in compradores_set {
+                if let Some((_, puntaje_total)) = self.marketplace.get_reputacion_comprador(comprador) {
+                    compradores_reputacion.push((comprador, puntaje_total));
+                }
+            }
+
+            compradores_reputacion.sort_by(|a, b| b.1.cmp(&a.1));
+            compradores_reputacion.into_iter().take(5).collect()
+        }
+
+        /// Ver productos más vendidos.
+        #[ink(message)]
+        pub fn productos_mas_vendidos(&self) -> Vec<(String, u32)> {
+            let cantidad_ordenes = self.marketplace.get_cantidad_ordenes();
+            let mut ventas_por_producto: BTreeMap<u32, u32> = BTreeMap::new();
+
+            for i in 0..cantidad_ordenes {
+                if let Some(orden) = self.marketplace.get_orden(i) {
+                    // Consideramos solo órdenes completadas (Recibido) o también Enviado?
+                    // El requerimiento dice "productos más vendidos", usualmente implica ventas concretadas.
+                    // Pero si la orden está creada, ya se "vendió" en teoría, aunque no se haya entregado.
+                    // Voy a contar todas las que no estén canceladas.
+                    if orden.estado != EstadoOrden::Cancelada {
+                         let count = ventas_por_producto.entry(orden.id_producto).or_insert(0);
+                         *count += orden.cant_producto as u32;
+                    }
+                }
+            }
+
+            let mut ranking: Vec<(String, u32)> = Vec::new();
+            for (id_producto, cantidad) in ventas_por_producto {
+                if let Some(producto) = self.marketplace.get_producto(id_producto) {
+                    ranking.push((producto.nombre, cantidad));
+                }
+            }
+
+            ranking.sort_by(|a, b| b.1.cmp(&a.1));
+            ranking
+        }
+
+        /// Estadísticas por categoría: total de ventas, calificación promedio.
+        /// Retorna Vec<(Categoria, TotalVentas, CalificacionPromedio)>
+        /// CalificacionPromedio: Asumiremos promedio de reputación de vendedores en esa categoría ponderado?
+        /// O simplemente promedio de reputación de los vendedores que vendieron en esa categoría.
+        /// Simplificación: Promedio de reputación de vendedores únicos que tienen ventas en esa categoría.
+        #[ink(message)]
+        pub fn estadisticas_por_categoria(&self) -> Vec<(Categoria, u128, u8)> {
+             let cantidad_ordenes = self.marketplace.get_cantidad_ordenes();
+             // Map: Categoria -> (TotalVentas, Set<Vendedores>)
+             // Como no tenemos Set, usaremos Vec y dedup.
+             
+             // Estructura temporal: Categoria -> (MontoTotal, Vec<Vendedor>)
+             // Categoria no implementa Copy/Clone trivialmente para usar como key en BTreeMap a veces,
+             // pero es un enum simple, debería.
+             // Pero BTreeMap necesita Ord. Categoria deriva PartialEq, Eq. Necesita PartialOrd, Ord.
+             // Asumiremos que podemos iterar y agrupar manualmente o usar un vector de acumuladores.
+             
+             // Dado que son pocas categorías (5), podemos usar un vector fijo o mapear manualmente.
+             
+             let mut stats: Vec<(Categoria, u128, Vec<AccountId>)> = Vec::new();
+             // Inicializar con las categorías conocidas si quisiéramos, o dinámicamente.
+             
+             for i in 0..cantidad_ordenes {
+                 if let Some(orden) = self.marketplace.get_orden(i) {
+                     if orden.estado != EstadoOrden::Cancelada {
+                         if let Some(producto) = self.marketplace.get_producto(orden.id_producto) {
+                             let categoria = producto.categoria;
+                             
+                             // Buscar si ya existe la categoría en stats
+                             let mut found = false;
+                             for stat in &mut stats {
+                                 if stat.0 == categoria {
+                                     stat.1 += orden.total;
+                                     if !stat.2.contains(&orden.vendedor) {
+                                         stat.2.push(orden.vendedor);
+                                     }
+                                     found = true;
+                                     break;
+                                 }
+                             }
+                             
+                             if !found {
+                                 let mut vendedores = Vec::new();
+                                 vendedores.push(orden.vendedor);
+                                 stats.push((categoria, orden.total, vendedores));
+                             }
+                         }
+                     }
+                 }
+             }
+             
+             let mut resultado: Vec<(Categoria, u128, u8)> = Vec::new();
+             
+             for (cat, total_ventas, vendedores) in stats {
+                 let mut suma_reputacion = 0;
+                 let mut count_vendedores = 0;
+                 
+                 for vendedor in vendedores {
+                     if let Some((cant_calif, puntaje_tot)) = self.marketplace.get_reputacion_vendedor(vendedor) {
+                         if cant_calif > 0 {
+                             suma_reputacion += puntaje_tot / cant_calif; // Promedio entero
+                             count_vendedores += 1;
+                         }
+                     }
+                 }
+                 
+                 let promedio_cat = if count_vendedores > 0 {
+                     (suma_reputacion / count_vendedores) as u8
+                 } else {
+                     0
+                 };
+                 
+                 resultado.push((cat, total_ventas, promedio_cat));
+             }
+             
+             resultado
+        }
+
+        /// Cantidad de órdenes por usuario.
+        #[ink(message)]
+        pub fn cantidad_ordenes_usuario(&self, usuario: AccountId) -> u32 {
+            let cantidad_ordenes = self.marketplace.get_cantidad_ordenes();
+            let mut count = 0;
+            for i in 0..cantidad_ordenes {
+                if let Some(orden) = self.marketplace.get_orden(i) {
+                    if orden.comprador == usuario || orden.vendedor == usuario {
+                        count += 1;
+                    }
+                }
+            }
+            count
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[ink::test]
+        fn new_works() {
+            let accounts = ink::env::test::default_accounts::<ink::env::DefaultEnvironment>();
+            // En unit tests, la llamada a contratos externos fallará si se intenta ejecutar.
+            // Solo probamos la instanciación aquí.
+            let _reportes = ReportesView::new(accounts.alice);
+        }
+    }
+}


### PR DESCRIPTION
## 📝 Descripción

<!-- Explica brevemente qué hace este PR y por qué es necesario -->

## ✅ Cambios realizados

- [X] Nuevo feature
- [ ] Bugfix
- [ ] Refactor
- [ ] Documentación
- [ ] Otro (especificar)

## 📦 Qué incluye este PR

<!-- Lista los cambios principales que hiciste -->


Resumen General
El contrato ReportesView actúa como un módulo de consulta y reportes para el contrato principal MarketPlace. Su función principal es agregar y procesar datos como órdenes, reputación y productos. Esto permite generar estadísticas útiles sin modificar el estado del mercado.

Constructor
new(marketplace_address: AccountId)
Inicializa el contrato almacenando la referencia al contrato MarketPlace. Esto habilita a ReportesView para realizar llamadas entre contratos (cross-contract calls) y leer los datos necesarios.

Funciones Principales (View Functions)
top_5_vendedores() -> Vec<(AccountId, u32)>
Devuelve una lista de los 5 vendedores con mejor reputación.

Lógica

- Obtiene la cantidad total de órdenes del mercado
- Itera sobre todas las órdenes para identificar a los vendedores únicos
- Consulta la reputación de cada vendedor mediante get_reputacion_vendedor
- Ordena a los vendedores por puntaje de mayor a menor y devuelve los 5 mejores

top_5_compradores() -> Vec<(AccountId, u32)>
Devuelve una lista de los 5 compradores con mejor reputación.

Lógica

- Extrae los compradores únicos de las órdenes
- Consulta la reputación usando get_reputacion_comprador
- Retorna los 5 mejores ordenados de forma descendente

productos_mas_vendidos() -> Vec<(String, u32)>
Genera un ranking de los productos con mayor cantidad de unidades vendidas. Retorna una lista de pares (NombreProducto, CantidadVendida).

Lógica

- Itera sobre todas las órdenes del mercado
- Filtra e ignora las órdenes que están en estado Cancelada
- Acumula la cantidad de productos vendidos por id_producto

Obtiene el nombre del producto para el reporte final

estadisticas_por_categoria() -> Vec<(Categoria, u128, u8)>
Provee estadísticas agrupadas por categoría de producto. Retorna una tupla con la categoría, el monto total de ventas y el promedio de reputación de los vendedores en esa categoría.

Lógica

- Agrupa las órdenes válidas (no canceladas) por categoría
- Suma el valor total de las ventas (orden.total) por categoría
- Calcula el promedio de reputación de los vendedores únicos dentro de cada grupo

cantidad_ordenes_usuario(usuario: AccountId) -> u32
Cuenta cuántas órdenes tiene un usuario específico, ya sea en rol de comprador o de vendedor.

Lógica

- Recorre todas las órdenes existentes
- Incrementa el contador si el usuario coincide con el campo comprador o vendedor de la orden


**Dependencia: El contrato depende fuertemente de las funciones "getter" expuestas por el contrato MarketPlace (get_orden, get_producto, get_reputacion_vendedor, etc.).**

## 🧪 ¿Cómo probarlo?

<!-- Describe cómo probar este PR paso a paso o con comandos -->

```sh
# comandos de ejemplo
cargo test
```
## 📋 Checklist antes de hacer merge

- [ ] He probado los cambios localmente
- [ ] La funcionalidad es coherente con la descripción del issue
- [ ] No hay errores en la compilación
- [ ] He escrito pruebas si aplica
```
